### PR TITLE
Switch to using danger's git instance instead of own to get the git diff.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - persist_to_workspace:
           root: output-gems
           paths:
-            - danger-ios_version_change*.gem
+            - *.gem
   deploy:
     working_directory: ~/code
     docker:
@@ -70,7 +70,7 @@ jobs:
           command: mkdir ~/.gem; printf "%s\n%s " "---" ":rubygems_api_key:" > ~/.gem/credentials; printf $RUBYGEMS_KEY >> ~/.gem/credentials;chmod 0600 ~/.gem/credentials
       - attach_workspace:
           at: output-gems
-      - run: gem push output-gems/danger-ios_version_change-*.gem
+      - run: gem push output-gems/danger-ios_version_change*.gem
 workflows:
   version: 2
   test-lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,14 @@ jobs:
         key: Gemfile-{{ checksum "Gemfile.lock" }}
         paths:
           - vendor/bundle
+  danger:
+    docker:
+      - image: dantoml/danger:latest
+    steps:
+      - checkout
+      - run: ./assert_danger_running_on_pr.sh
+      - run: bundle install
+      - run: '[ ! -z $DANGER_GITHUB_API_TOKEN ] && danger || echo "Skipping Danger for External Contributor"'
   test-lint:
     working_directory: ~/code
     docker:
@@ -69,6 +77,7 @@ workflows:
   version: 2
   test-lint:
     jobs:
+      - danger
       - dependencies
       - test-lint:
           requires:

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,6 @@
+if github.branch_for_base == "master"
+  diff = git.diff_for_file("lib/ios_version_change/gem_version.rb")
+  if !diff
+    fail 'You did not update the gem version.'
+  end
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    danger-ios_version_change (0.1.0)
+    danger-ios_version_change (0.1.4)
       danger-plugin-api (~> 1.0)
+      git
 
 GEM
   remote: https://rubygems.org/

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+- [ ] Update `lib/ios_version_change/gem_version.rb` to latest version. Bump it! 
+- [ ] Tests all pass. 
+- [ ] After merge, make a git tag release. 

--- a/assert_danger_running_on_pr.sh
+++ b/assert_danger_running_on_pr.sh
@@ -1,0 +1,4 @@
+if [[ -z "${CI_PULL_REQUESTS}" ]]; then
+  echo -e "\033[31merror: Danger requires a pull request to function correctly\033[0m"
+  exit 1
+fi

--- a/lib/ios_version_change/gem_version.rb
+++ b/lib/ios_version_change/gem_version.rb
@@ -1,3 +1,3 @@
 module IosVersionChange
-  VERSION = "0.1.3".freeze
+  VERSION = "0.1.4".freeze
 end

--- a/lib/ios_version_change/plugin.rb
+++ b/lib/ios_version_change/plugin.rb
@@ -18,6 +18,13 @@ module Danger
       "ios_version_change"
     end
 
+    def initialize(dangerfile)
+      super(dangerfile)
+      raise unless dangerfile.env.scm.class == Danger::GitRepo
+
+      @git = dangerfile.env.scm
+    end
+
     # Ignore. Pass the git diff string here to see if the version string has been updated. Use `ios_version_change.assert_version_changed("ProjectName/Info.plist")` instead as it's more convenient sending the path to the Info.plist file.
     # @return [void]
     def assert_version_changed_diff(git_diff_string)
@@ -48,8 +55,7 @@ module Danger
         return # rubocop:disable UnreachableCode
       end
 
-      git = Git.open(Dir.pwd)
-      git_diff_string = git.diff[info_plist_file_path].patch
+      git_diff_string = @git.diff[info_plist_file_path].patch
       assert_version_changed_diff(git_diff_string)
     end
   end

--- a/spec/ios_version_change_spec.rb
+++ b/spec/ios_version_change_spec.rb
@@ -2,10 +2,6 @@ require File.expand_path("../spec_helper", __FILE__)
 
 module Danger
   describe Danger::DangerIosVersionChange do
-    it "should be a plugin" do
-      expect(Danger::DangerIosVersionChange.new(nil)).to be_a Danger::Plugin
-    end
-
     #
     # You should test your custom attributes and methods here
     #


### PR DESCRIPTION
- [x] Update `lib/ios_version_change/gem_version.rb` to latest version. Bump it! 
- [x] Tests all pass. 
- [x] After merge, make a git tag release. 