### PR TITLE
Fix git diff crash by checking if a diff exists for a file.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run: ./assert_danger_running_on_pr.sh
       - run: bundle install
-      - run: '[ ! -z $DANGER_GITHUB_API_TOKEN ] && danger || echo "Skipping Danger for External Contributor" && exit 1'
+      - run: '[ ! -z $DANGER_GITHUB_API_TOKEN ] && danger || echo "Skipping Danger for External Contributor"'
   test-lint:
     working_directory: ~/code
     docker:

--- a/lib/ios_version_change/gem_version.rb
+++ b/lib/ios_version_change/gem_version.rb
@@ -1,3 +1,3 @@
 module IosVersionChange
-  VERSION = "0.1.4".freeze
+  VERSION = "0.1.5".freeze
 end

--- a/lib/ios_version_change/plugin.rb
+++ b/lib/ios_version_change/plugin.rb
@@ -55,6 +55,11 @@ module Danger
         return # rubocop:disable UnreachableCode
       end
 
+      unless @git.diff.include?(info_plist_file_path) # No diff found for Info.plist file.
+        fail "You did not change the iOS version."
+        return # rubocop:disable UnreachableCode
+      end
+
       git_diff_string = @git.diff[info_plist_file_path].patch
       assert_version_changed_diff(git_diff_string)
     end


### PR DESCRIPTION
- [x] Update `lib/ios_version_change/gem_version.rb` to latest version. Bump it! 
- [x] Tests all pass. 
- [x] After merge, make a git tag release. 
