### PR TITLE
Plugin now using danger's core git diff method to truly get most accu…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in danger-ios_version_change.gemspec
 gemspec
 
-# Added at 2017-12-01 15:36:57 -0600 by levibostian:
-gem "git", "~> 1.3"
-
 # Added at 2017-12-04 17:20:03 -0600 by levibostian:
 gem "rspec_junit_formatter", "~> 0.3.0"

--- a/danger-ios_version_change.gemspec
+++ b/danger-ios_version_change.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'git'
+#  spec.add_runtime_dependency 'git'
 
   spec.add_runtime_dependency 'danger-plugin-api', '~> 1.0'
 

--- a/lib/ios_version_change/gem_version.rb
+++ b/lib/ios_version_change/gem_version.rb
@@ -1,3 +1,3 @@
 module IosVersionChange
-  VERSION = "0.1.5".freeze
+  VERSION = "0.1.6".freeze
 end

--- a/lib/ios_version_change/plugin.rb
+++ b/lib/ios_version_change/plugin.rb
@@ -1,4 +1,3 @@
-require "git"
 
 module Danger
   # Asserts the version string has been changed in your iOS XCode project.
@@ -20,9 +19,6 @@ module Danger
 
     def initialize(dangerfile)
       super(dangerfile)
-      raise unless dangerfile.env.scm.class == Danger::GitRepo
-
-      @git = dangerfile.env.scm
     end
 
     # Ignore. Pass the git diff string here to see if the version string has been updated. Use `ios_version_change.assert_version_changed("ProjectName/Info.plist")` instead as it's more convenient sending the path to the Info.plist file.
@@ -55,12 +51,12 @@ module Danger
         return # rubocop:disable UnreachableCode
       end
 
-      unless @git.diff.include?(info_plist_file_path) # No diff found for Info.plist file.
-        fail "You did not change the iOS version."
+      unless git.diff_for_file(info_plist_file_path) # No diff found for Info.plist file.
+        fail "You did not edit your Info.plist file at all. Therefore, you did not change the iOS version."
         return # rubocop:disable UnreachableCode
       end
 
-      git_diff_string = @git.diff[info_plist_file_path].patch
+      git_diff_string = git.diff_for_file(info_plist_file_path).patch
       assert_version_changed_diff(git_diff_string)
     end
   end


### PR DESCRIPTION
…rate git diff of file to stop failing when Info.plist actually changes.

- [x] Update `lib/ios_version_change/gem_version.rb` to latest version. Bump it! 
- [x] Tests all pass. 
- [x] After merge, make a git tag release. 
